### PR TITLE
feat: micro de búsqueda de documento en Python

### DIFF
--- a/python_buscar_documento_micro/main.py
+++ b/python_buscar_documento_micro/main.py
@@ -1,0 +1,46 @@
+import json
+import logging
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+from .models import ResponseBuscarDocumento
+from .service import AlfrescoClient, DocumentoService
+
+logging.basicConfig(level=logging.INFO)
+
+ALFRESCO_URL = os.getenv("ALFRESCO_URL", "http://alfresco.local")
+ALFRESCO_CREDENTIALS = os.getenv("ALFRESCO_CREDENTIALS", "")
+service = DocumentoService(AlfrescoClient(ALFRESCO_URL, ALFRESCO_CREDENTIALS))
+
+
+class BuscarDocumentoHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/buscar_documento_radicado/"):
+            id_doc = parsed.path.split("/")[-1]
+            logging.info("Inicio buscar documento por idRadicado %s", id_doc)
+            result: ResponseBuscarDocumento = service.buscar_documento(id_doc)
+            logging.info("Respuesta buscar documento por idRadicado Respuesta: %s", result)
+            body = json.dumps(result.to_dict()).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header(
+                "Set-Cookie",
+                "JSESSIONID=9B9DAA8EFCCECFDBEB7E3E337871FE3A; HttpOnly; Secure",
+            )
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404, "Not Found")
+
+
+def run(host: str = "0.0.0.0", port: int = 8000):
+    server = HTTPServer((host, port), BuscarDocumentoHandler)
+    logging.info("Servidor iniciado en %s:%s", host, port)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/python_buscar_documento_micro/models.py
+++ b/python_buscar_documento_micro/models.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List
+
+
+@dataclass
+class Documento:
+    id: str
+    nombre: str
+    descripcion: str
+    propiedades: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ResponseBuscarDocumento:
+    idRadicado: str
+    estado: int
+    mensaje: str
+    documentos: List[Documento]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "idRadicado": self.idRadicado,
+            "estado": self.estado,
+            "mensaje": self.mensaje,
+            "documentos": [d.to_dict() for d in self.documentos],
+        }

--- a/python_buscar_documento_micro/service.py
+++ b/python_buscar_documento_micro/service.py
@@ -1,0 +1,61 @@
+import json
+from typing import Any, Dict, List
+from urllib import request
+
+from .models import Documento, ResponseBuscarDocumento
+
+
+class AlfrescoClient:
+    """Cliente minimalista para comunicarse con el servicio de Alfresco."""
+
+    def __init__(self, base_url: str, credentials: str):
+        self.base_url = base_url.rstrip("/")
+        self.credentials = credentials
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Basic {self.credentials}"}
+
+    def _get(self, url: str) -> Dict[str, Any]:
+        req = request.Request(url, headers=self._headers())
+        with request.urlopen(req) as resp:
+            data = resp.read()
+        return json.loads(data.decode("utf-8"))
+
+    def get_node_children(self, node_id: str) -> List[Dict[str, Any]]:
+        url = f"{self.base_url}/nodes/{node_id}/children"
+        data = self._get(url)
+        return data["list"]["entries"]
+
+    def get_node(self, node_id: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/nodes/{node_id}"
+        return self._get(url)
+
+
+class DocumentoService:
+    def __init__(self, client: AlfrescoClient):
+        self.client = client
+
+    def buscar_documento(self, id_documento: str) -> ResponseBuscarDocumento:
+        entries = self.client.get_node_children(id_documento)
+        documentos: List[Documento] = []
+        for node in entries:
+            node_id = node["entry"]["id"]
+            archivo = self.client.get_node(node_id)
+            entry = archivo["entry"]
+            nombre = entry["name"]
+            descripcion = "Documento principal" if nombre.startswith("pp-") else "Documento secundario"
+            propiedades = entry.get("properties", {})
+            documentos.append(
+                Documento(
+                    id=entry["id"],
+                    nombre=nombre,
+                    descripcion=descripcion,
+                    propiedades=propiedades,
+                )
+            )
+        return ResponseBuscarDocumento(
+            idRadicado=id_documento,
+            estado=200,
+            mensaje="OK",
+            documentos=documentos,
+        )

--- a/python_buscar_documento_micro/tests/test_buscar_documento.py
+++ b/python_buscar_documento_micro/tests/test_buscar_documento.py
@@ -1,0 +1,49 @@
+import json
+import os
+import sys
+import threading
+from http.server import HTTPServer
+from urllib import request
+
+# Asegurar que el paquete pueda importarse cuando se ejecuta desde la raíz del repositorio
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from python_buscar_documento_micro import main
+from python_buscar_documento_micro.service import DocumentoService
+
+
+class FakeClient:
+    def get_node_children(self, node_id):
+        return [{"entry": {"id": "child1"}}, {"entry": {"id": "child2"}}]
+
+    def get_node(self, node_id):
+        nombre = "pp-archivo" if node_id == "child1" else "ss-archivo"
+        return {
+            "entry": {
+                "id": node_id,
+                "name": nombre,
+                "properties": {"prop1": "valor"},
+            }
+        }
+
+
+def test_buscar_documento_endpoint(monkeypatch):
+    fake_service = DocumentoService(FakeClient())
+    monkeypatch.setattr(main, "service", fake_service)
+    server = HTTPServer(("localhost", 0), main.BuscarDocumentoHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    try:
+        port = server.server_port
+        resp = request.urlopen(f"http://localhost:{port}/buscar_documento_radicado/123")
+        assert resp.status == 200
+        data = json.loads(resp.read().decode())
+        assert data["idRadicado"] == "123"
+        assert "JSESSIONID=9B9DAA8EFCCECFDBEB7E3E337871FE3A" in resp.headers.get("Set-Cookie")
+        assert len(data["documentos"]) == 2
+        assert data["documentos"][0]["descripcion"] == "Documento principal"
+        assert data["documentos"][1]["descripcion"] == "Documento secundario"
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- crea microservicio en Python para `buscar_documento_radicado`
- incorpora cliente y servicio para consultar nodos de Alfresco
- agrega pruebas unitarias del endpoint

## Testing
- `pytest python_buscar_documento_micro/tests/test_buscar_documento.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689820c2a6588330a25d173308918801